### PR TITLE
fix: setup monit config in entrypoint fixes errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM alpine:latest
 
 RUN apk add --update monit bash curl
-RUN mkdir -p /var/lib/monit /etc/monit/monit.d \
-  && mv /etc/monitrc /etc/monit/ \
-  && sed -i 's/^#.*include.*\/etc\/monit.d\/\*/include \/etc\/monit\/monit.d\/*/' /etc/monit/monitrc
+COPY docker-entrypoint.sh /
 
 VOLUME /etc/monit
 EXPOSE 2812
-ENTRYPOINT ["monit", "-c", "/etc/monit/monitrc", "-I"]
+ENTRYPOINT ["bash", "/docker-entrypoint.sh"]
+CMD ["monit", "-c", "/etc/monit/monitrc", "-I"]

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,12 +3,11 @@ FROM arm32v7/alpine:latest
 # For cross building on amd64 host
 COPY qemu-arm-static /usr/bin
 
-
-RUN apk add --update monit bash curl
-RUN mkdir -p /var/lib/monit /etc/monit/monit.d \
-  && mv /etc/monitrc /etc/monit/ \
-  && sed -i 's/^#.*include.*\/etc\/monit.d\/\*/include \/etc\/monit\/monit.d\/*/' /etc/monit/monitrc
+RUN apk add --update monit bash curl \
+  && mkdir -p /var/lib/monit /etc/monit/monit.d
+COPY docker-entrypoint.sh /
 
 VOLUME /etc/monit
 EXPOSE 2812
-ENTRYPOINT ["monit", "-c", "/etc/monit/monitrc", "-I"]
+ENTRYPOINT ["bash", "/docker-entrypoint.sh"]
+CMD ["monit", "-c", "/etc/monit/monitrc", "-I"]

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -4,10 +4,9 @@ FROM arm64v8/alpine:latest
 COPY qemu-aarch64-static /usr/bin
 
 RUN apk add --update monit bash curl
-RUN mkdir -p /var/lib/monit /etc/monit/monit.d \
-  && mv /etc/monitrc /etc/monit/ \
-  && sed -i 's/^#.*include.*\/etc\/monit.d\/\*/include \/etc\/monit\/monit.d\/*/' /etc/monit/monitrc
+COPY docker-entrypoint.sh /
 
 VOLUME /etc/monit
 EXPOSE 2812
-ENTRYPOINT ["monit", "-c", "/etc/monit/monitrc", "-I"]
+ENTRYPOINT ["bash", "/docker-entrypoint.sh"]
+CMD ["monit", "-c", "/etc/monit/monitrc", "-I"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ -f /etc/monitrc ]; then
+  mv /etc/monitrc /etc/monit/ \
+  && sed -i 's/^#.*include.*\/etc\/monit.d\/\*/include \/etc\/monit\/monit.d\/*/' /etc/monit/monitrc
+fi
+
+exec "$@"


### PR DESCRIPTION
We need to setup monit config after volume is mounted.
This should fix monit & keep config in volume.